### PR TITLE
repair iframe scaling and positioning problems on Android 4.x native browsers

### DIFF
--- a/src/controller/projekktor.js
+++ b/src/controller/projekktor.js
@@ -1052,7 +1052,7 @@ projekktor = $p = function() {
                 iframeWidth: target.attr('width') || 0,
                 iframeHeight: target.attr('height') || 0
             }).css({
-        position: 'fixed',
+        position: 'absolute',
         display: 'block',
         top: 0,
         left: 0,
@@ -1383,7 +1383,7 @@ projekktor = $p = function() {
         try {
             var result = false;
             if(this.config._iframe)
-                parent.location.host || false;
+                result = parent.location.host || false;
             return (result===false) ? false : $(parent.window);
         } catch(e) { return false; }        
     };
@@ -2968,25 +2968,25 @@ projekktor = $p = function() {
     this._start = function(data) {
 
         var ref = this,
-                files=[];
+            iframeParent = this.getIframeParent();
 
         // load and initialize plugins
         this._registerPlugins();
 
 
         // set up iframe environment
-        if (this.config._iframe===true) {        
-        if (this.getIframeParent()) {
-            this.getIframeParent().ready(function() {
-            ref._enterFullViewport(true);
-            });
-        } else {
-            ref._enterFullViewport(true);
-        }
+        if (this.config._iframe === true) {
+            if (iframeParent) {
+                iframeParent.ready(function() {
+                    ref._enterFullViewport(true);
+                });
+            } else {
+                ref._enterFullViewport(true);
+            }
         }
 
             // cross domain
-            if (this.getIframeParent()===false) {
+            if (iframeParent===false) {
                 this.config._isCrossDomain = true;
             }
      


### PR DESCRIPTION
Fix for a bug which prevents Android 4.x native browser users from displaying video at all if the projekktor was used inside the iframe and in iframe mode. Poster and video, if visible, was badly positioned and scaled. 
