### PR TITLE
Fix native audio video model and inline HLS support

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -53,6 +53,7 @@ module.exports = function (grunt) {
           "src/models/player.js",
           "src/models/player.NA.js",
           "src/models/player.audio.video.js",
+          "src/models/player.audio.video.hls.js",
           "src/models/player.audio.video.vlc.js",
           "src/models/player.playlist.js",
           "src/models/player.image.html.js",          

--- a/src/models/player.audio.video.hls.js
+++ b/src/models/player.audio.video.hls.js
@@ -11,30 +11,32 @@ jQuery(function($) {
     
 $p.newModel({    
     modelId: 'VIDEOHLS',    
-    androidVersion: "4", // 
-    iosVersion: "3",
-    nativeVersion: "1",
+    androidVersion: 4,
+    iosVersion: 3,    
     iLove: [
-        {ext:'m3u8', type:'application/x-mpegURL', platform: ['ios', 'android', 'native'], streamType: ['http','httpVideo', 'httpVideoLive']},
-        {ext:'m3u', type:'application/x-mpegURL', platform: ['ios', 'android', 'native'], streamType: ['http', 'httpVideo', 'httpVideoLive']},   
-        {ext:'m3u8', type:'application/vnd.apple.mpegURL', platform: ['ios', 'android', 'native'], streamType: ['http','httpVideo', 'httpVideoLive']},
-        {ext:'m3u', type:'application/vnd.apple.mpegURL', platform: ['ios', 'android', 'native'], streamType: ['http', 'httpVideo', 'httpVideoLive']} 
+        {ext:'m3u8', type:'application/mpegURL', platform: ['ios', 'android'], streamType: ['http','httpVideo', 'httpVideoLive']},
+        {ext:'m3u', type:'application/mpegURL', platform: ['ios', 'android'], streamType: ['http', 'httpVideo', 'httpVideoLive']},
+        {ext:'m3u8', type:'application/vnd.apple.mpegURL', platform: ['ios', 'android'], streamType: ['http','httpVideo', 'httpVideoLive']},
+        {ext:'m3u', type:'application/vnd.apple.mpegURL', platform: ['ios', 'android'], streamType: ['http', 'httpVideo', 'httpVideoLive']},             
+        {ext:'m3u8', type:'application/x-mpegURL', platform: ['ios', 'android'], streamType: ['http','httpVideo', 'httpVideoLive']},
+        {ext:'m3u', type:'application/x-mpegURL', platform: ['ios', 'android'], streamType: ['http', 'httpVideo', 'httpVideoLive']}    
     ]
     
 }, 'VIDEO');
 
 $p.newModel({    
     modelId: 'AUDIOHLS',    
-    androidVersion: "4",
-    iosVersion: "3",
-    nativeVersion: "1",
+    androidVersion: 4,
+    iosVersion: 3,
     iLove: [
-        {ext:'m3u8', type:'application/x-mpegURL', platform: ['ios', 'android', 'native'], streamType: ['http','httpAudio', 'httpAudioLive']},
-        {ext:'m3u', type:'application/x-mpegURL', platform: ['ios', 'android', 'native'], streamType: ['http','httpAudio', 'httpAudioLive']},
-        {ext:'m3u8', type:'application/vnd.apple.mpegURL', platform: ['ios', 'android', 'native'], streamType: ['http','httpAudio', 'httpAudioLive']},
-        {ext:'m3u', type:'application/vnd.apple.mpegURL', platform: ['ios', 'android', 'native'], streamType: ['http','httpAudio', 'httpAudioLive']},                 
-        {ext:'m3u8', type:'audio/mpegURL', platform: ['ios', 'android', 'native'], streamType: ['http','httpAudio', 'httpAudioLive']},
-        {ext:'m3u', type:'audio/mpegURL', platform: ['ios', 'android', 'native'], streamType: ['http', 'httpAudio', 'httpAudioLive']}
+        {ext:'m3u8', type:'application/mpegURL', platform: ['ios', 'android'], streamType: ['http','httpAudio', 'httpAudioLive']},
+        {ext:'m3u', type:'application/mpegURL', platform: ['ios', 'android'], streamType: ['http','httpAudio', 'httpAudioLive']},
+        {ext:'m3u8', type:'application/vnd.apple.mpegURL', platform: ['ios', 'android'], streamType: ['http','httpAudio', 'httpAudioLive']},
+        {ext:'m3u', type:'application/vnd.apple.mpegURL', platform: ['ios', 'android'], streamType: ['http','httpAudio', 'httpAudioLive']},             
+        {ext:'m3u8', type:'application/x-mpegURL', platform: ['ios', 'android'], streamType: ['http','httpAudio', 'httpAudioLive']},
+        {ext:'m3u', type:'application/x-mpegURL', platform: ['ios', 'android'], streamType: ['http','httpAudio', 'httpAudioLive']},    
+        {ext:'m3u8', type:'audio/mpegURL', platform: ['ios', 'android'], streamType: ['http','httpAudio', 'httpAudioLive']},
+        {ext:'m3u', type:'audio/mpegURL', platform: ['ios', 'android'], streamType: ['http', 'httpAudio', 'httpAudioLive']}
     ]
     
 }, 'AUDIO');

--- a/src/models/player.audio.video.hls.js
+++ b/src/models/player.audio.video.hls.js
@@ -1,0 +1,42 @@
+/*
+ * this file is part of: 
+ * projekktor zwei
+ * http://www.projekktor.com
+ *
+ * Copyright 2014, Sascha Kluger, Spinning Airwhale Media, http://www.spinningairwhale.com
+ * under GNU General Public License
+ * http://www.filenew.org/projekktor/license/
+*/
+jQuery(function($) {
+    
+$p.newModel({    
+    modelId: 'VIDEOHLS',    
+    androidVersion: "4", // 
+    iosVersion: "3",
+    nativeVersion: "1",
+    iLove: [
+        {ext:'m3u8', type:'application/x-mpegURL', platform: ['ios', 'android', 'native'], streamType: ['http','httpVideo', 'httpVideoLive']},
+        {ext:'m3u', type:'application/x-mpegURL', platform: ['ios', 'android', 'native'], streamType: ['http', 'httpVideo', 'httpVideoLive']},   
+        {ext:'m3u8', type:'application/vnd.apple.mpegURL', platform: ['ios', 'android', 'native'], streamType: ['http','httpVideo', 'httpVideoLive']},
+        {ext:'m3u', type:'application/vnd.apple.mpegURL', platform: ['ios', 'android', 'native'], streamType: ['http', 'httpVideo', 'httpVideoLive']} 
+    ]
+    
+}, 'VIDEO');
+
+$p.newModel({    
+    modelId: 'AUDIOHLS',    
+    androidVersion: "4",
+    iosVersion: "3",
+    nativeVersion: "1",
+    iLove: [
+        {ext:'m3u8', type:'application/x-mpegURL', platform: ['ios', 'android', 'native'], streamType: ['http','httpAudio', 'httpAudioLive']},
+        {ext:'m3u', type:'application/x-mpegURL', platform: ['ios', 'android', 'native'], streamType: ['http','httpAudio', 'httpAudioLive']},
+        {ext:'m3u8', type:'application/vnd.apple.mpegURL', platform: ['ios', 'android', 'native'], streamType: ['http','httpAudio', 'httpAudioLive']},
+        {ext:'m3u', type:'application/vnd.apple.mpegURL', platform: ['ios', 'android', 'native'], streamType: ['http','httpAudio', 'httpAudioLive']},                 
+        {ext:'m3u8', type:'audio/mpegURL', platform: ['ios', 'android', 'native'], streamType: ['http','httpAudio', 'httpAudioLive']},
+        {ext:'m3u', type:'audio/mpegURL', platform: ['ios', 'android', 'native'], streamType: ['http', 'httpAudio', 'httpAudioLive']}
+    ]
+    
+}, 'AUDIO');
+
+});


### PR DESCRIPTION
Repaired Android <= 4.2.2 native browser issues with gray screen instead of video, impossibility of pausing video by touching the screen and many others. HLS inline video support on Android >= 4.1 and iOS devices. VIDEOHLS and AUDIOHLS models moved into separate file for readability and to easily exclude the functionality if needed
