### PR TITLE
Enhanced cuepoints system

### DIFF
--- a/src/controller/projekktor.js
+++ b/src/controller/projekktor.js
@@ -2418,6 +2418,7 @@ projekktor = $p = function() {
             precision: (obj.precision==null) ? 1 : obj.precision,
             title: (obj.title==null) ? '' : obj.title,
             once: obj.once || false,
+            blipEvents: obj.blipEvents || [],
             
             _listeners: [],
             _unlocked: false,


### PR DESCRIPTION
Enhance, fix and cleanup cuepoints functionality
[new features]
core:
- new API methods for cuepoints get, add, remove actions
- new global events introduced: cuepoint, cuepointsAdd, cuepointsRemove, cuepointsSync
- introduced "once" cuepoints, which are triggered only once and then immediately removed
- introduced wildcarded cuepoints "*", which are added to all playlist items

controlbar plugin:
- now all cuepoint blips have additional CSS classes to identify relevant cuepoint id and group so that it's possible to individually style every blip or style their groups
- now it's possible to display only selected groups of cuepoints by providing their names in showCuePointGroups config array
- new config options: showCuePointsImmediately, showCuePointGroups, minCuePointSize, cuePointEvents 
- now it's possible to add any event listener (e.g. click, mouseover etc.) to all of the cuepoint blips globally (through controlbar plugin config.cuePointEvents param) or locally for any individual blip (through cuepoint blipEvents object)

[fixed issues and enhancements]
core:
- assign cuepoints to improper playlist item after playlist manipulations (e.g. when the VAST plugin injected preroll, the cuepoints defined for the first playlist item were triggered within preroll, not within first user playlist item). Now cuepoints are assigned to playlist item ID and not to its index.
- fixed event listeners removal
- automatic cuepoints resync after cuepoints add/remove actions
- callback is fed with original cuepoint object, not the shortened one, which allows to make any kind of conditions based on the cuepoint params

controlbar plugin:
- automatic cuepoint blips refreshment after playlist item cuepoints were added or removed
