### PR TITLE
Add native HLS support for Safari on OSX

### DIFF
--- a/src/controller/projekktor.js
+++ b/src/controller/projekktor.js
@@ -268,7 +268,7 @@ projekktor = $p = function() {
             checkFor = [],
             st = streamType || 'http',
             pltfrm = (typeof platform=='object') ? platform : [platform],
-            type = (mediaType) ? mediaType.replace(/x-/, '') : undefined,
+            type = (mediaType) ? mediaType.toLowerCase() : undefined,
             tm = ref._testMediaSupport();
 
         $.each(pltfrm, function(nothing, plt) {
@@ -432,8 +432,8 @@ projekktor = $p = function() {
                         if (codecMatch[1]!=null) {
                             data.file[index].codec = codecMatch[1];                
                         }
-                        data.file[index].type = codecMatch[0].replace(/x-/, '');
-                        data.file[index].originalType = codecMatch[0];
+                        data.file[index].type = codecMatch[0].toLowerCase(); // mimeTypes are case insensitive
+                        data.file[index].originalType = codecMatch[0].toLowerCase();
                     } catch(e){}
                 }
                 else {
@@ -485,7 +485,7 @@ projekktor = $p = function() {
                 if (data.file[index].type==null)
                     continue;
                 
-                if ( ($.inArray( data.file[index].type.replace(/x-/, ''), types)<0) && modelSet.type!='none/none') {
+                if ( ($.inArray(data.file[index].type, types) < 0) && modelSet.type != 'none/none') {
                     continue;
                 }
                 
@@ -1461,7 +1461,7 @@ projekktor = $p = function() {
             for (var i in this.media[this._currentItem].file) {
                 if (this.media[this._currentItem].file.hasOwnProperty(i)) {
                     for (var j in platforms) {
-                        if (this._canPlay(this.media[this._currentItem].file[i].type.replace(/x-/, ''), platforms[j].toLowerCase(), this.getConfig('streamType')) ) {
+                        if (this._canPlay(this.media[this._currentItem].file[i].type, platforms[j].toLowerCase(), this.getConfig('streamType')) ) {
                             if ($.inArray(platforms[j].toLowerCase(), result)==-1) {
                                 result.push(platforms[j].toLowerCase());
                             }

--- a/src/models/player.audio.video.hls.js
+++ b/src/models/player.audio.video.hls.js
@@ -14,12 +14,10 @@ $p.newModel({
     androidVersion: 4,
     iosVersion: 3,    
     iLove: [
-        {ext:'m3u8', type:'application/mpegURL', platform: ['ios', 'android'], streamType: ['http','httpVideo', 'httpVideoLive']},
-        {ext:'m3u', type:'application/mpegURL', platform: ['ios', 'android'], streamType: ['http', 'httpVideo', 'httpVideoLive']},
-        {ext:'m3u8', type:'application/vnd.apple.mpegURL', platform: ['ios', 'android'], streamType: ['http','httpVideo', 'httpVideoLive']},
-        {ext:'m3u', type:'application/vnd.apple.mpegURL', platform: ['ios', 'android'], streamType: ['http', 'httpVideo', 'httpVideoLive']},             
-        {ext:'m3u8', type:'application/x-mpegURL', platform: ['ios', 'android'], streamType: ['http','httpVideo', 'httpVideoLive']},
-        {ext:'m3u', type:'application/x-mpegURL', platform: ['ios', 'android'], streamType: ['http', 'httpVideo', 'httpVideoLive']}    
+        {ext:'m3u8', type:'application/vnd.apple.mpegurl', platform: ['ios', 'android', 'native'], streamType: ['http','httpVideo', 'httpVideoLive']},
+        {ext:'m3u', type:'application/vnd.apple.mpegurl', platform: ['ios', 'android', 'native'], streamType: ['http', 'httpVideo', 'httpVideoLive']},             
+        {ext:'m3u8', type:'application/x-mpegurl', platform: ['ios', 'android', 'native'], streamType: ['http','httpVideo', 'httpVideoLive']},
+        {ext:'m3u', type:'application/x-mpegurl', platform: ['ios', 'android', 'native'], streamType: ['http', 'httpVideo', 'httpVideoLive']}    
     ]
     
 }, 'VIDEO');
@@ -29,14 +27,14 @@ $p.newModel({
     androidVersion: 4,
     iosVersion: 3,
     iLove: [
-        {ext:'m3u8', type:'application/mpegURL', platform: ['ios', 'android'], streamType: ['http','httpAudio', 'httpAudioLive']},
-        {ext:'m3u', type:'application/mpegURL', platform: ['ios', 'android'], streamType: ['http','httpAudio', 'httpAudioLive']},
-        {ext:'m3u8', type:'application/vnd.apple.mpegURL', platform: ['ios', 'android'], streamType: ['http','httpAudio', 'httpAudioLive']},
-        {ext:'m3u', type:'application/vnd.apple.mpegURL', platform: ['ios', 'android'], streamType: ['http','httpAudio', 'httpAudioLive']},             
-        {ext:'m3u8', type:'application/x-mpegURL', platform: ['ios', 'android'], streamType: ['http','httpAudio', 'httpAudioLive']},
-        {ext:'m3u', type:'application/x-mpegURL', platform: ['ios', 'android'], streamType: ['http','httpAudio', 'httpAudioLive']},    
-        {ext:'m3u8', type:'audio/mpegURL', platform: ['ios', 'android'], streamType: ['http','httpAudio', 'httpAudioLive']},
-        {ext:'m3u', type:'audio/mpegURL', platform: ['ios', 'android'], streamType: ['http', 'httpAudio', 'httpAudioLive']}
+        {ext:'m3u8', type:'application/vnd.apple.mpegurl', platform: ['ios', 'android', 'native'], streamType: ['http','httpAudio', 'httpAudioLive']},
+        {ext:'m3u', type:'application/vnd.apple.mpegurl', platform: ['ios', 'android', 'native'], streamType: ['http','httpAudio', 'httpAudioLive']},             
+        {ext:'m3u8', type:'application/x-mpegurl', platform: ['ios', 'android', 'native'], streamType: ['http','httpAudio', 'httpAudioLive']},
+        {ext:'m3u', type:'application/x-mpegurl', platform: ['ios', 'android', 'native'], streamType: ['http','httpAudio', 'httpAudioLive']},    
+        {ext:'m3u8', type:'audio/mpegurl', platform: ['ios', 'android', 'native'], streamType: ['http','httpAudio', 'httpAudioLive']},
+        {ext:'m3u', type:'audio/mpegurl', platform: ['ios', 'android', 'native'], streamType: ['http', 'httpAudio', 'httpAudioLive']},
+        {ext:'m3u8', type:'audio/x-mpegurl', platform: ['ios', 'android', 'native'], streamType: ['http','httpAudio', 'httpAudioLive']},
+        {ext:'m3u', type:'audio/x-mpegurl', platform: ['ios', 'android', 'native'], streamType: ['http', 'httpAudio', 'httpAudioLive']}
     ]
     
 }, 'AUDIO');

--- a/src/models/player.audio.video.osmf.js
+++ b/src/models/player.audio.video.osmf.js
@@ -23,8 +23,7 @@ $p.newModel({
         {ext:'mov', type:'video/quicktime', platform:'flash', streamType: ['*']},
         {ext:'m4v', type:'video/mp4', platform:'flash', fixed: true, streamType: ['*']},
         {ext:'f4m', type:'application/f4m+xml', platform:'flash', fixed: true, streamType: ['*']},
-        {ext:'m3u8', type:'application/mpegURL', platform:'flash', fixed: true, streamType: ['*']},
-        {ext:'m3u8', type:'application/x-mpegURL', platform:'flash', fixed: true, streamType: ['*']},
+        {ext:'m3u8', type:'application/x-mpegurl', platform:'flash', fixed: true, streamType: ['*']},
         {ext:'m3u8', type:'application/vnd.apple.mpegurl', platform:'flash', fixed: true, streamType: ['*']},
         {ext:'manifest', type:'application/vnd.ms-ss', platform:'flash', fixed: true, streamType: ['*']}
     ],
@@ -458,7 +457,15 @@ $p.newModel({
     iLove: [
         {ext:'mp3', type:'audio/mp3', platform:'flash', streamType: ['*']},
         {ext:'m4a', type:'audio/mp4', platform:'flash', streamType: ['*']},
-        {ext:'m4a', type:'audio/mpeg', platform:'flash', streamType: ['*']}    
+        {ext:'m4a', type:'audio/mpeg', platform:'flash', streamType: ['*']},
+        {ext:'m3u8', type:'application/vnd.apple.mpegurl', platform: 'flash', streamType: ['*']},
+        {ext:'m3u', type:'application/vnd.apple.mpegurl', platform: 'flash', streamType: ['*']},             
+        {ext:'m3u8', type:'application/x-mpegurl', platform: 'flash', streamType: ['*']},
+        {ext:'m3u', type:'application/x-mpegurl', platform: 'flash', streamType: ['*']},    
+        {ext:'m3u8', type:'audio/mpegurl', platform: 'flash', streamType: ['*']},
+        {ext:'m3u', type:'audio/mpegurl', platform: 'flash', streamType: ['*']},
+        {ext:'m3u8', type:'audio/x-mpegurl', platform: 'flash', streamType: ['*']},
+        {ext:'m3u', type:'audio/x-mpegurl', platform: 'flash', streamType: ['*']}
     ],
     
     applyMedia: function(destContainer) {

--- a/src/models/player.audio.video.vlc.js
+++ b/src/models/player.audio.video.vlc.js
@@ -43,7 +43,7 @@ $p.newModel({
                         var ref = navigator.plugins[i][j];
                         if (ref.suffixes!=null && ref.type!=null) {
                             $.each(ref.suffixes.split(','), function(key, value) {
-                                model.iLove.push( {ext:value, type: ref.type.replace(/x-/, ''), platform:['vlc'], streamType: ['rtsp', 'http', 'pseudo', 'httpVideo', 'multipart']} );
+                                model.iLove.push( {ext:value.toLowerCase(), type: ref.type.toLowerCase(), platform:['vlc'], streamType: ['rtsp', 'http', 'pseudo', 'httpVideo', 'multipart']} );
                             })
                         }
                     }


### PR DESCRIPTION
- Remove improper HLS mimeTypes for HLS video: 'application/mpegurl' and added proper one for HLS audio: 'application/x-mpegurl'
- Fix comparison of declared mimeType in item config and that from iLove model array to be case insensitive, cause mimeTypes are case insensitive (RFC2045)
- x- prefix is now left if it's declared cause it's an important part of mimeType E.g. Safari on OSX returns 'maybe' for canUseType('application/x-mpegurl') but empty string for canUseType('application/mpegurl')
