### PR TITLE
allow to start video playback with muted

### DIFF
--- a/src/plugins/projekktor.controlbar.js
+++ b/src/plugins/projekktor.controlbar.js
@@ -255,6 +255,7 @@ jQuery(function ($) {
         config: {
             /* Plugin: cb - enable/disable fade away of overlayed controls */
             toggleMute: false,
+            startMuted: false,
             showCuePoints: false,
             fadeDelay: 2500,
             showOnStart: false,
@@ -294,6 +295,12 @@ jQuery(function ($) {
 
             this.addGuiListeners();
             this.hidecb(true);
+
+            // allow to start "mute" but keep initial volume
+            if (this.getConfig('startMuted')) {
+                this.cookie('volume', this._getVolume());
+                this.cookie('muted', true);
+            }
             this.pluginReady = true;
         },
 


### PR DESCRIPTION
I had no success to set "volume" to 0 to start video playback muted with toggleMute, because projekktor toggles between 0 and 0. This change still allow to setup a config value for volume, but initially starts muted, if "config.startMuted" is true.
