### PR TITLE
possible fix to show correct initial video quality in controlbar

### DIFF
--- a/src/models/player.audio.video.js
+++ b/src/models/player.audio.video.js
@@ -105,7 +105,8 @@ $p.newModel({
          * instead of <video> 'src' attribute.
          */
         this.mediaElement.attr('src', media[0].src);
-        
+        this._quality = media[0].quality;
+
         /* Some Android Gingerbread devices will not play video when
          * the <video> 'type' attribute is set explicitly 
          */


### PR DESCRIPTION
If a video with two (or maybe more) available qualities is shown, internal '_quality' property never gets updated - so the controlbar is unable to ask for the currently (initial) played video quality and show "HQ" while "SD" may be the initial default.
